### PR TITLE
Date range picker fixes

### DIFF
--- a/app/src/components/MyPayroll/PaymentFilters.js
+++ b/app/src/components/MyPayroll/PaymentFilters.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import SingleDatePicker from '../SingleDatePicker/SingleDatePicker'
-import { DropDown, GU } from '@aragon/ui'
+import { DateRangePicker, DropDown, GU } from '@aragon/ui'
 
 function PaymentFilters({
   dateFilter,
@@ -26,7 +25,7 @@ function PaymentFilters({
         onChange={onTokenChange}
         width="140px"
       />
-      <SingleDatePicker startDate={dateFilter} onChange={onDateChange} />
+      <DateRangePicker startDate={dateFilter} onChange={onDateChange} />
     </div>
   )
 }

--- a/app/src/components/SingleDatePicker/DatePicker.js
+++ b/app/src/components/SingleDatePicker/DatePicker.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { GU, eachDayOfInterval } from '@aragon/ui'
+import { eachDayOfInterval, GU } from '@aragon/ui'
 import MonthDay from './MonthDay'
 import { Selector } from './components'
 import { dayjs } from '../../utils/date-utils'

--- a/app/src/components/SingleDatePicker/DatePicker.js
+++ b/app/src/components/SingleDatePicker/DatePicker.js
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import dayjs from 'dayjs'
 import { GU, eachDayOfInterval } from '@aragon/ui'
 import MonthDay from './MonthDay'
-
-const { Selector } = require('@aragon/ui/dist/components')
+import { Selector } from './components'
+import { dayjs } from '../../utils/date-utils'
 
 function DatePicker({
   initialDate,

--- a/app/src/components/SingleDatePicker/Labels.js
+++ b/app/src/components/SingleDatePicker/Labels.js
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import ButtonBase, {
+import {
+  ButtonBase,
   IconCalendar,
   GU,
   RADIUS,

--- a/app/src/components/SingleDatePicker/MonthDay.js
+++ b/app/src/components/SingleDatePicker/MonthDay.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'styled-components'
 import { useTheme, textStyle, GU } from '@aragon/ui'
-const { HoverIndicator } = require('@aragon/ui/dist/components')
+import { HoverIndicator } from './components'
 
 function MonthDay({ children, disabled, selected, today, weekDay, ...props }) {
   const theme = useTheme()

--- a/app/src/components/SingleDatePicker/SingleDatePicker.js
+++ b/app/src/components/SingleDatePicker/SingleDatePicker.js
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import Popover, { useTheme, GU, RADIUS } from '@aragon/ui'
+import { Popover, GU, RADIUS, useTheme } from '@aragon/ui'
 import DatePicker from './DatePicker'
 import Labels from './Labels'
 import { SINGLE_DATE } from './consts'
-import { dayjs } from '../../utils/date-utils'
-import { handleSingleDateSelect } from './utils'
+import { dayjs, dateFormat } from '../../utils/date-utils'
+import handleSingleDateSelect from './utils'
 
 function SingleDatePicker({ format, onChange, startDate: startDateProp }) {
   const theme = useTheme()
@@ -31,7 +31,7 @@ function SingleDatePicker({ format, onChange, startDate: startDateProp }) {
   const labelProps = useMemo(() => {
     const _startDate = startDate
     return {
-      startText: _startDate ? dayjs(_startDate).format(format) : SINGLE_DATE,
+      startText: _startDate ? dateFormat(_startDate, format) : SINGLE_DATE,
     }
   }, [format, startDate])
 

--- a/app/src/components/SingleDatePicker/SingleDatePicker.js
+++ b/app/src/components/SingleDatePicker/SingleDatePicker.js
@@ -1,10 +1,10 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import dayjs from 'dayjs'
 import Popover, { useTheme, GU, RADIUS } from '@aragon/ui'
 import DatePicker from './DatePicker'
 import Labels from './Labels'
 import { SINGLE_DATE } from './consts'
+import { dayjs } from '../../utils/date-utils'
 import { handleSingleDateSelect } from './utils'
 
 function SingleDatePicker({ format, onChange, startDate: startDateProp }) {

--- a/app/src/components/SingleDatePicker/components.js
+++ b/app/src/components/SingleDatePicker/components.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+import {
+  ButtonBase,
+  GU,
+  IconLeft,
+  IconRight,
+  textStyle,
+  useTheme,
+} from '@aragon/ui'
+
+export const HoverIndicator = styled.span`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  border-radius: 50%;
+  ${({ theme, selected }) => css`
+    background: ${selected ? theme.selected : theme.surface};
+    border: 2px solid ${theme.accent};
+  `}
+`
+
+const ArrowButton = props => {
+  const theme = useTheme()
+  return (
+    <ButtonBase
+      focusRingRadius={GU * 2}
+      css={`
+        font-size: 9px;
+        padding: 5px 4px 0 4px;
+        margin-top: -4px;
+        color: ${theme.hint};
+
+        &:hover {
+          color: inherit;
+        }
+      `}
+      {...props}
+    />
+  )
+}
+
+const SelectorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${1 * GU}px;
+
+  span {
+    ${({ small, theme }) => css`
+      ${textStyle(small ? 'label2' : 'body2')};
+      ${small &&
+        css`
+          color: ${theme.hint};
+          font-weight: 600;
+        `}
+    `}
+  }
+`
+
+// eslint-disable-next-line react/prop-types
+export function Selector({ prev, next, children, small }) {
+  const theme = useTheme()
+  return (
+    <SelectorWrapper small={small} theme={theme}>
+      <ArrowButton onClick={prev}>
+        <IconLeft size="small" />
+      </ArrowButton>
+      <span>{children}</span>
+      <ArrowButton onClick={next}>
+        <IconRight size="small" />
+      </ArrowButton>
+    </SelectorWrapper>
+  )
+}

--- a/app/src/components/SingleDatePicker/utils.js
+++ b/app/src/components/SingleDatePicker/utils.js
@@ -1,4 +1,5 @@
-import dayjs from 'dayjs'
+import { dayjs } from '../../utils/date-utils'
+
 function handleSingleDateSelect({ date, startDate }) {
   // clicking on start date resets it, so it can be re-picked
   if (startDate && dayjs(date).isSame(startDate, 'day')) {

--- a/app/src/components/SingleDatePicker/utils.js
+++ b/app/src/components/SingleDatePicker/utils.js
@@ -16,4 +16,5 @@ function handleSingleDateSelect({ date, startDate }) {
     }
   }
 }
+
 export default handleSingleDateSelect

--- a/app/src/panels/AddEmployee.js
+++ b/app/src/panels/AddEmployee.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import BN from 'bn.js'
 import { useAppState } from '@aragon/api-react'
@@ -11,10 +12,11 @@ import {
   TextInput,
   useSidePanelFocusOnReady,
 } from '@aragon/ui'
-import styled from 'styled-components'
+import SingleDatePicker from '../components/SingleDatePicker/SingleDatePicker'
+
 import { toDecimals } from '../utils/math-utils'
 import { addressesEqual, isAddress } from '../utils/web3-utils'
-import { SECONDS_IN_A_YEAR, dayjs, dateFormat } from '../utils/date-utils'
+import { SECONDS_IN_A_YEAR, dayjs } from '../utils/date-utils'
 
 const ADDRESS_NOT_AVAILABLE_ERROR = Symbol('ADDRESS_NOT_AVAILABLE_ERROR')
 const ADDRESS_INVALID_FORMAT = Symbol('ADDRESS_INVALID_FORMAT')
@@ -167,12 +169,10 @@ function AddEmployeePanelContent({
 
         {/* TODO: Use better date picker */}
         <Field label="Start Date">
-          <TextInput
-            value={dateFormat(startDate, 'iso')}
+          <SingleDatePicker
+            startDate={startDate}
+            format="iso"
             onChange={handleStartDateChange}
-            required
-            wide
-            type="date"
           />
         </Field>
 


### PR DESCRIPTION
Fixes the `styled-components` weird error. It was caused mainly when importing some components as defaults from `@aragon/ui` 

```
import ButtonBase` from '@aragon/ui'
```
 when it should be: 
```
 import { ButtonBase } from '@aragon/ui'
```

Also added the `components.js` file so we don't import directly from `@aragon/ui/dist` folder
and updated the `dayjs` import since we import it from `utils/date-utils.js` across all the app.

